### PR TITLE
(#2832) - don't store 'follows' key for multipart

### DIFF
--- a/lib/routes/document.js
+++ b/lib/routes/document.js
@@ -69,6 +69,10 @@ module.exports = function(app, PouchDB) {
         });
       }).on('close', function () {
         promise.then(function () {
+          // don't store the "follows" key
+          Object.keys(doc._attachments).forEach(function (filename) {
+            delete doc._attachments[filename].follows;
+          });
           // merge, since it could be a mix of stubs and non-stubs
           doc._attachments = extend(true, doc._attachments, attachments);
           req.db.put(doc, opts, onResponse);


### PR DESCRIPTION
This is required for pouchdb/pouchdb#3876 to pass.